### PR TITLE
User helper

### DIFF
--- a/bootstrap/helpers.php
+++ b/bootstrap/helpers.php
@@ -1,0 +1,21 @@
+<?php
+
+use App\Models\User;
+
+/**
+ * Get the currently authenticated user model.
+ */
+function user(): User
+{
+    $currentUser = auth()->user();
+
+    if ($currentUser === null) {
+        throw new Exception('The current user is not authenticated.');
+    }
+
+    if (! $currentUser instanceof User) {
+        throw new Exception('The currently authenticated user is not an instance of '.User::class);
+    }
+
+    return $currentUser;
+}

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,8 @@
             "App\\": "app/",
             "Database\\Factories\\": "database/factories/",
             "Database\\Seeders\\": "database/seeders/"
-        }
+        },
+        "files": ["bootstrap/helpers.php"]
     },
     "autoload-dev": {
         "psr-4": {


### PR DESCRIPTION
This adds a `user()` helper function to the base application, which is type-hinted to return an instance of the App\Models\User class by default.

**Why?**

`auth()->user()` is handy, and widely used in Laravel projects, but its return typehint is for a `Illuminate\Contracts\Auth\Authenticatable` instance.

While this may be valid from a framework perspective, and there are many uses for Authenticatables that are not the User model, most Laravel applications use the defaults. Therefore, users expect an instance of the User model returned.

This means that, without the help of third-party tools like [laravel-ide-helper](https://github.com/barryvdh/laravel-ide-helper), as developers we get a poor experience when getting the authenticated user and expecting the model:

No IDE support for chaining methods/properties
Static analysis fails if we chain anything not on the Authenticatable interface
We have to typehint /** @var \App\Models\User $user */ everywhere we use the helper
By adding this to the basic application scaffold, the new user() helper can get proper typehinting for the out-of-the-box User model that ships with a fresh application, supporting proper typehinting. As it is in the userland instead of the framework, it can be changed to support other Authenticatables if the developer wishes.

**Why should this be in the base application?**

Yes, users could always add this helper manually to their app, but having a standard way the framework does it will eventually bring consistency to new applications—and I believe this utility is used commonly enough that it warrants being in the base.

There's clearly [some interest](https://x.com/LiamHammett/status/1900568350599885168) in it, and people have a dozen of their own home-grown solutions for the same problem, something this could provide.

**Why not in the framework?**

`App\Models\User` is defined in the user's application, so the framework has no knowledge of it or if it changes names/namespaces/etc.